### PR TITLE
feat(Helm): Added initial Helm Chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - master
+      - release/*
+  pull_request:
+    branches: 
+      - master
+      - release/*
 jobs:
   build:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,21 @@ jobs:
     - name: Unit tests
       run: |
         make test/unit
-    - name: Run e2e tests
-      run: |
-        make setup/github
-        sudo chown -R $USER $HOME/.kube $HOME/.minikube
-        make cluster/prepare 
-        make test/e2e
-    - name: Run e2e tests for local image
-      run: |
-        make test/e2e-local-image
-    - name: After failure
-      if: ${{ failure() }}
-      run: |
-        echo "---- Keycloak Server logs ----"
-        kubectl logs keycloak-0
-        echo "---- Testing Ingress ----"
-        curl -kv https://keycloak.local/auth
-        echo "---- Ingress Controller logs ----"
-        kubectl logs -l app.kubernetes.io/name=nginx-ingress-controller -n kube-system
+    # - name: Run e2e tests
+    #   run: |
+    #     make setup/github
+    #     sudo chown -R $USER $HOME/.kube $HOME/.minikube
+    #     make cluster/prepare 
+    #     make test/e2e
+    # - name: Run e2e tests for local image
+    #   run: |
+    #     make test/e2e-local-image
+    # - name: After failure
+    #   if: ${{ failure() }}
+    #   run: |
+    #     echo "---- Keycloak Server logs ----"
+    #     kubectl logs keycloak-0
+    #     echo "---- Testing Ingress ----"
+    #     curl -kv https://keycloak.local/auth
+    #     echo "---- Ingress Controller logs ----"
+    #     kubectl logs -l app.kubernetes.io/name=nginx-ingress-controller -n kube-system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,21 @@ jobs:
     - name: Unit tests
       run: |
         make test/unit
+    - name: Start minikube
+      uses: manusa/actions-setup-minikube@v2.3.1
+      with:
+        minikube version: 'v1.16.0'
+        kubernetes version: 'v1.19.2'
+        driver: 'docker'
+    - name: Configure Minikube
+      run: |
+        minikube addons enable ingress
+        hack/modify_etc_hosts.sh "keycloak.local"
     - name: Run e2e tests
       run: |
-        make setup/github
-        sudo chown -R $USER $HOME/.kube $HOME/.minikube
-        make cluster/prepare 
+        make cluster/prepare
         make test/e2e
-    # - name: Run e2e tests for local image
-    #   run: |
-    #     make test/e2e-local-image
-    # - name: After failure
-    #   if: ${{ failure() }}
-    #   run: |
-    #     echo "---- Keycloak Server logs ----"
-    #     kubectl logs keycloak-0
-    #     echo "---- Testing Ingress ----"
-    #     curl -kv https://keycloak.local/auth
-    #     echo "---- Ingress Controller logs ----"
-    #     kubectl logs -l app.kubernetes.io/name=nginx-ingress-controller -n kube-system
+        make cluster/clean
+    - name: Run e2e tests for local image
+      run: |
+        make test/e2e-local-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
     - name: Unit tests
       run: |
         make test/unit
-    # - name: Run e2e tests
-    #   run: |
-    #     make setup/github
-    #     sudo chown -R $USER $HOME/.kube $HOME/.minikube
-    #     make cluster/prepare 
-    #     make test/e2e
+    - name: Run e2e tests
+      run: |
+        make setup/github
+        sudo chown -R $USER $HOME/.kube $HOME/.minikube
+        make cluster/prepare 
+        make test/e2e
     # - name: Run e2e tests for local image
     #   run: |
     #     make test/e2e-local-image

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,13 @@
 name: Go
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - master
+      - release/*
+  pull_request:
+    branches: 
+      - master
+      - release/*
 jobs:
   build:
     name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,13 @@
 name: Lint
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - master
+      - release/*
+  pull_request:
+    branches: 
+      - master
+      - release/*
 jobs:
   golangci:
     name: lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS build-env
+FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS build-env
 
 COPY . /src/
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ NAMESPACE=keycloak
 PROJECT=keycloak-operator
 PKG=github.com/keycloak/keycloak-operator
 OPERATOR_SDK_VERSION=v0.18.2
-OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu
-MINIKUBE_DOWNLOAD_URL=https://github.com/kubernetes/minikube/releases/download/v1.9.2/minikube-linux-amd64
-KUBECTL_DOWNLOAD_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+ifeq ($(shell uname),Darwin)
+  OPERATOR_SDK_ARCHITECTURE=x86_64-apple-darwin
+else
+  OPERATOR_SDK_ARCHITECTURE=x86_64-linux-gnu
+endif
+OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_ARCHITECTURE)
 
 # Compile constants
 COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
@@ -29,13 +32,12 @@ cluster/prepare:
 
 .PHONY: cluster/clean
 cluster/clean:
-	@kubectl get all -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	@kubectl get roles,rolebindings,serviceaccounts keycloak-operator -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	@kubectl get pv,pvc -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	# Remove all CRDS with keycloak.org in the name
-	@kubectl get crd --no-headers=true -o name | awk '/keycloak.org/{print $1}' | xargs kubectl delete || true
+	@kubectl delete -f deploy/service_account.yaml -n $(NAMESPACE) || true
+	@kubectl delete -f deploy/role_binding.yaml -n $(NAMESPACE) || true
+	@kubectl delete -f deploy/role.yaml -n $(NAMESPACE) || true
 	@kubectl delete namespace $(NAMESPACE) || true
-
+	@kubectl delete -f deploy/crds/ || true
+	
 .PHONY: cluster/clean/monitoring
 cluster/clean/monitoring:
 	@kubectl delete -n $(NAMESPACE) --all blackboxtargets
@@ -51,6 +53,7 @@ cluster/clean/monitoring:
 
 .PHONY: cluster/prepare/monitoring
 cluster/prepare/monitoring:
+	oc label namespace $(NAMESPACE) "monitoring-key=middleware"
 	$(eval _OS_PROMETHEUS_USER=$(shell oc get secrets -n openshift-monitoring grafana-datasources -o 'go-template={{index .data "prometheus.yaml"}}' | base64 --decode | jq -r '.datasources[0].basicAuthUser'))
 	$(eval _OS_PROMETHEUS_PASS=$(shell oc get secrets -n openshift-monitoring grafana-datasources -o 'go-template={{index .data "prometheus.yaml"}}' | base64 --decode | jq -r '.datasources[0].basicAuthPassword'))
 	kubectl label namespace $(NAMESPACE) monitoring-key=middleware || true
@@ -90,12 +93,20 @@ test/ibm-validation:
 	@echo Running the operator image in the cluster
 	operator-sdk test local ./test/e2e --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --operator-namespace $(NAMESPACE) --debug --verbose --global-manifest=deploy/empty-init.yaml --namespaced-manifest=deploy/operator.yaml
 
-.PHONY: test/e2e-local-image cluster/prepare setup/operator-sdk
-test/e2e-local-image: cluster/prepare setup/operator-sdk
-	@echo Running e2e tests with a fresh built operator image in the cluster:
+.PHONY: test/e2e-local-image setup/operator-sdk
+test/e2e-local-image: setup/operator-sdk
+	@echo Backing up operator.yaml
+	@cp deploy/operator.yaml deploy/operator.yaml_bckp
+	@echo Building operator image:
+	eval $$(minikube -p minikube docker-env); \
 	docker build . -t keycloak-operator:test
-	@echo Running tests:
-	operator-sdk test local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --image="keycloak-operator:test" --operator-namespace $(NAMESPACE) --up-local --debug --verbose ./test/e2e
+	@echo Modifying operator.yaml
+	@sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' deploy/operator.yaml
+	@echo Creating namespace
+	kubectl create namespace $(NAMESPACE) || true
+	@echo Running e2e tests with a fresh built operator image in the cluster:
+	trap 'mv -f deploy/operator.yaml_bckp deploy/operator.yaml' EXIT; \
+	operator-sdk test local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --image="keycloak-operator:test" --debug --verbose --operator-namespace $(NAMESPACE) ./test/e2e
 
 .PHONY: test/coverage/prepare
 test/coverage/prepare:
@@ -154,7 +165,7 @@ code/compile:
 	@GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -o=$(COMPILE_TARGET) -mod=vendor ./cmd/manager
 
 .PHONY: code/gen
-code/gen:
+code/gen: client/gen
 	operator-sdk generate k8s
 	operator-sdk generate crds --crd-version v1beta1
 	# This is a copy-paste part of `operator-sdk generate openapi` command (suggested by the manual)
@@ -179,21 +190,17 @@ code/lint:
 	@echo "--> Running golangci-lint"
 	@$(shell go env GOPATH)/bin/golangci-lint run --timeout 10m
 
-##############################
-# CI                         #
-##############################
-.PHONY: setup/github
-setup/github:
-	@echo Installing Kubectl
-	@curl -Lo kubectl ${KUBECTL_DOWNLOAD_URL} && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-	@echo Installing Minikube
-	@curl -Lo minikube ${MINIKUBE_DOWNLOAD_URL} && chmod +x minikube && sudo mv minikube /usr/local/bin/
-	@echo Booting Minikube up, see Travis env. variables for more information
-	@mkdir -p $HOME/.kube $HOME/.minikube
-	@touch $KUBECONFIG
-	@sudo minikube start --vm-driver=none
-	@sudo ./hack/modify_etc_hosts.sh "keycloak.local"
-	@sudo minikube addons enable ingress
+.PHONY: client/gen
+client/gen:
+	@echo "--> Running code-generator to generate clients"
+	# prepare tool code-generator
+	@mkdir -p ./tmp/code-generator
+	@git clone https://github.com/kubernetes/code-generator.git --branch v0.21.0-alpha.2 --single-branch  ./tmp/code-generator
+	# generate client
+	./tmp/code-generator/generate-groups.sh "client,informer,lister" github.com/keycloak/keycloak-operator/pkg/client github.com/keycloak/keycloak-operator/pkg/apis keycloak:v1alpha1 --output-base ./tmp --go-header-file ./hack/boilerplate.go.txt
+	# check generated client at ./pkg/client
+	@cp -r ./tmp/github.com/keycloak/keycloak-operator/pkg/client/* ./pkg/client/
+	@rm -rf ./tmp/github.com ./tmp/code-generator
 
 .PHONY: test/goveralls
 test/goveralls: test/coverage/prepare

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test/e2e-local-image: cluster/prepare setup/operator-sdk
 	@echo Running e2e tests with a fresh built operator image in the cluster:
 	docker build . -t keycloak-operator:test
 	@echo Running tests:
-	operator-sdk test local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --image="keycloak-operator:test" --namespace $(NAMESPACE) --up-local --debug --verbose ./test/e2e
+	operator-sdk test local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --image="keycloak-operator:test" --operator-namespace $(NAMESPACE) --up-local --debug --verbose ./test/e2e
 
 .PHONY: test/coverage/prepare
 test/coverage/prepare:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Kubernetes Operator based on the Operator SDK for creating and syncing resourc
 ## Help and Documentation
 
 The official documentation might be found in the [here](https://www.keycloak.org/docs/latest/server_installation/index.html#_operator).
+The Vibrent documentation can be found [here](https://agile.vignetcorp.com:8086/confluence/display/AC/Keycloak+Operator).
 
 * [Keycloak documentation](https://www.keycloak.org/documentation.html)
 * [User Mailing List](https://lists.jboss.org/mailman/listinfo/keycloak-user) - Mailing list for help and general questions about Keycloak

--- a/charts/keycloak-operator/.helmignore
+++ b/charts/keycloak-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for the Keycloak Operator
+name: keycloak-operator
+version: 1.0.0

--- a/charts/keycloak-operator/crds/keycloak.org_keycloakbackups_crd.yaml
+++ b/charts/keycloak-operator/crds/keycloak.org_keycloakbackups_crd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KeycloakBackup is the Schema for the keycloakbackups API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+          properties:
+            aws:
+              description: If provided, an automatic database backup will be created
+                on AWS S3 instead of a local Persistent Volume. If this property is
+                not provided - a local Persistent Volume backup will be chosen.
+              properties:
+                credentialsSecretName:
+                  description: "Provides a secret name used for connecting to AWS
+                    S3 Service. The secret needs to be in the following form: \n     apiVersion:
+                    v1     kind: Secret     metadata:       name: <Secret name>     type:
+                    Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>
+                    \      AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY:
+                    <AWS Secret Key> \n For more information, please refer to the
+                    Operator documentation."
+                  type: string
+                encryptionKeySecretName:
+                  description: "If provided, the database backup will be encrypted.
+                    Provides a secret name used for encrypting database data. The
+                    secret needs to be in the following form: \n     apiVersion: v1
+                    \    kind: Secret     metadata:       name: <Secret name>     type:
+                    Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>
+                    \      GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT:
+                    <GPG Recipient> \n For more information, please refer to the Operator
+                    documentation."
+                  type: string
+                schedule:
+                  description: If specified, it will be used as a schedule for creating
+                    a CronJob.
+                  type: string
+              type: object
+            instanceSelector:
+              description: Selector for looking up Keycloak Custom Resources.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            restore:
+              description: "Controls automatic restore behavior. Currently not implemented.
+                \n In the future this will be used to trigger automatic restore for
+                a given KeycloakBackup. Each backup will correspond to a single snapshot
+                of the database (stored either in a Persistent Volume or AWS). If
+                a user wants to restore it, all he/she needs to do is to change this
+                flag to true. Potentially, it will be possible to restore a single
+                backup multiple times."
+              type: boolean
+            storageClassName:
+              description: Name of the StorageClass for Postgresql Backup Persistent
+                Volume Claim
+              type: string
+          type: object
+        status:
+          description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+          properties:
+            message:
+              description: Human-readable message indicating details about current
+                operator phase or error.
+              type: string
+            phase:
+              description: Current phase of the operator.
+              type: string
+            ready:
+              description: True if all resources are in a ready state and all work
+                is done.
+              type: boolean
+            secondaryResources:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              description: 'A map of all the secondary resources types and names created
+                for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                ]'
+              type: object
+          required:
+          - message
+          - phase
+          - ready
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/keycloak-operator/crds/keycloak.org_keycloakclients_crd.yaml
+++ b/charts/keycloak-operator/crds/keycloak.org_keycloakclients_crd.yaml
@@ -1,0 +1,438 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KeycloakClient is the Schema for the keycloakclients API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeycloakClientSpec defines the desired state of KeycloakClient.
+          properties:
+            client:
+              description: Keycloak Client REST object.
+              properties:
+                access:
+                  additionalProperties:
+                    type: boolean
+                  description: Access options.
+                  type: object
+                adminUrl:
+                  description: Application Admin URL.
+                  type: string
+                attributes:
+                  additionalProperties:
+                    type: string
+                  description: Client Attributes.
+                  type: object
+                baseUrl:
+                  description: Application base URL.
+                  type: string
+                bearerOnly:
+                  description: True if a client supports only Bearer Tokens.
+                  type: boolean
+                clientAuthenticatorType:
+                  description: What Client authentication type to use.
+                  type: string
+                clientId:
+                  description: Client ID.
+                  type: string
+                consentRequired:
+                  description: True if Consent Screen is required.
+                  type: boolean
+                defaultClientScopes:
+                  description: A list of default client scopes. Default client scopes
+                    are always applied when issuing OpenID Connect tokens or SAML
+                    assertions for this client.
+                  items:
+                    type: string
+                  type: array
+                defaultRoles:
+                  description: Default Client roles.
+                  items:
+                    type: string
+                  type: array
+                description:
+                  description: Client description.
+                  type: string
+                directAccessGrantsEnabled:
+                  description: True if Direct Grant is enabled.
+                  type: boolean
+                enabled:
+                  description: Client enabled flag.
+                  type: boolean
+                frontchannelLogout:
+                  description: True if this client supports Front Channel logout.
+                  type: boolean
+                fullScopeAllowed:
+                  description: True if Full Scope is allowed.
+                  type: boolean
+                id:
+                  description: Client ID. If not specified, automatically generated.
+                  type: string
+                implicitFlowEnabled:
+                  description: True if Implicit flow is enabled.
+                  type: boolean
+                name:
+                  description: Client name.
+                  type: string
+                nodeReRegistrationTimeout:
+                  description: Node registration timeout.
+                  type: integer
+                notBefore:
+                  description: Not Before setting.
+                  type: integer
+                optionalClientScopes:
+                  description: A list of optional client scopes. Optional client scopes
+                    are applied when issuing tokens for this client, but only when
+                    they are requested by the scope parameter in the OpenID Connect
+                    authorization request.
+                  items:
+                    type: string
+                  type: array
+                protocol:
+                  description: Protocol used for this Client.
+                  type: string
+                protocolMappers:
+                  description: Protocol Mappers.
+                  items:
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: Config options.
+                        type: object
+                      consentRequired:
+                        description: True if Consent Screen is required.
+                        type: boolean
+                      consentText:
+                        description: Text to use for displaying Consent Screen.
+                        type: string
+                      id:
+                        description: Protocol Mapper ID.
+                        type: string
+                      name:
+                        description: Protocol Mapper Name.
+                        type: string
+                      protocol:
+                        description: Protocol to use.
+                        type: string
+                      protocolMapper:
+                        description: Protocol Mapper to use
+                        type: string
+                    type: object
+                  type: array
+                publicClient:
+                  description: True if this is a public Client.
+                  type: boolean
+                redirectUris:
+                  description: A list of valid Redirection URLs.
+                  items:
+                    type: string
+                  type: array
+                rootUrl:
+                  description: Application root URL.
+                  type: string
+                secret:
+                  description: Client Secret. The Operator will automatically create
+                    a Secret based on this value.
+                  type: string
+                serviceAccountsEnabled:
+                  description: True if Service Accounts are enabled.
+                  type: boolean
+                standardFlowEnabled:
+                  description: True if Standard flow is enabled.
+                  type: boolean
+                surrogateAuthRequired:
+                  description: Surrogate Authentication Required option.
+                  type: boolean
+                useTemplateConfig:
+                  description: True to use a Template Config.
+                  type: boolean
+                useTemplateMappers:
+                  description: True to use Template Mappers.
+                  type: boolean
+                useTemplateScope:
+                  description: True to use Template Scope.
+                  type: boolean
+                webOrigins:
+                  description: A list of valid Web Origins.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - clientId
+              type: object
+            realmSelector:
+              description: Selector for looking up KeycloakRealm Custom Resources.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            roles:
+              description: Client Roles
+              items:
+                description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: Role Attributes
+                    type: object
+                  clientRole:
+                    description: Client Role
+                    type: boolean
+                  composite:
+                    description: Composite
+                    type: boolean
+                  composites:
+                    description: Composites
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Map client => []role
+                        type: object
+                      realm:
+                        description: Realm roles
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  containerId:
+                    description: Container Id
+                    type: string
+                  description:
+                    description: Description
+                    type: string
+                  id:
+                    description: Id
+                    type: string
+                  name:
+                    description: Name
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - name
+              x-kubernetes-list-type: map
+            scopeMappings:
+              description: Scope Mappings
+              properties:
+                clientMappings:
+                  additionalProperties:
+                    description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                    properties:
+                      client:
+                        description: Client
+                        type: string
+                      id:
+                        description: ID
+                        type: string
+                      mappings:
+                        description: Mappings
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  description: Client Mappings
+                  type: object
+                realmMappings:
+                  description: Realm Mappings
+                  items:
+                    description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+          required:
+          - client
+          - realmSelector
+          type: object
+        status:
+          description: KeycloakClientStatus defines the observed state of KeycloakClient
+          properties:
+            message:
+              description: Human-readable message indicating details about current
+                operator phase or error.
+              type: string
+            phase:
+              description: Current phase of the operator.
+              type: string
+            ready:
+              description: True if all resources are in a ready state and all work
+                is done.
+              type: boolean
+            secondaryResources:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              description: 'A map of all the secondary resources types and names created
+                for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                ]'
+              type: object
+          required:
+          - message
+          - phase
+          - ready
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/keycloak-operator/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/charts/keycloak-operator/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -1,0 +1,875 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KeycloakRealm is the Schema for the keycloakrealms API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+          properties:
+            instanceSelector:
+              description: Selector for looking up Keycloak Custom Resources.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            realm:
+              description: Keycloak Realm REST object.
+              properties:
+                accountTheme:
+                  description: Account Theme
+                  type: string
+                adminEventsDetailsEnabled:
+                  description: 'Enable admin events details TODO: change to values
+                    and use kubebuilder default annotation once supported'
+                  type: boolean
+                adminEventsEnabled:
+                  description: 'Enable events recording TODO: change to values and
+                    use kubebuilder default annotation once supported'
+                  type: boolean
+                adminTheme:
+                  description: Admin Console Theme
+                  type: string
+                attributes:
+                  additionalProperties:
+                    type: string
+                  description: Attributes
+                  type: object
+                authenticationFlows:
+                  description: Authentication flows
+                  items:
+                    properties:
+                      alias:
+                        description: Alias
+                        type: string
+                      authenticationExecutions:
+                        description: Authentication executions
+                        items:
+                          properties:
+                            authenticator:
+                              description: Authenticator
+                              type: string
+                            authenticatorConfig:
+                              description: Authenticator Config
+                              type: string
+                            authenticatorFlow:
+                              description: Authenticator flow
+                              type: boolean
+                            flowAlias:
+                              description: Flow Alias
+                              type: string
+                            priority:
+                              description: Priority
+                              format: int32
+                              type: integer
+                            requirement:
+                              description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE,
+                                DISABLED]
+                              type: string
+                            userSetupAllowed:
+                              description: User setup allowed
+                              type: boolean
+                          type: object
+                        type: array
+                      builtIn:
+                        description: Built in
+                        type: boolean
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: ID
+                        type: string
+                      providerId:
+                        description: Provider ID
+                        type: string
+                      topLevel:
+                        description: Top level
+                        type: boolean
+                    required:
+                    - alias
+                    - authenticationExecutions
+                    type: object
+                  type: array
+                authenticatorConfig:
+                  description: Authenticator config
+                  items:
+                    properties:
+                      alias:
+                        description: Alias
+                        type: string
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: Config
+                        type: object
+                      id:
+                        description: ID
+                        type: string
+                    required:
+                    - alias
+                    type: object
+                  type: array
+                bruteForceProtected:
+                  description: Brute Force Detection
+                  type: boolean
+                clientScopeMappings:
+                  additionalProperties:
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  description: Client Scope Mappings
+                  type: object
+                clientScopes:
+                  description: Client scopes
+                  items:
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description:
+                        type: string
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      protocol:
+                        type: string
+                      protocolMappers:
+                        description: Protocol Mappers.
+                        items:
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config options.
+                              type: object
+                            consentRequired:
+                              description: True if Consent Screen is required.
+                              type: boolean
+                            consentText:
+                              description: Text to use for displaying Consent Screen.
+                              type: string
+                            id:
+                              description: Protocol Mapper ID.
+                              type: string
+                            name:
+                              description: Protocol Mapper Name.
+                              type: string
+                            protocol:
+                              description: Protocol to use.
+                              type: string
+                            protocolMapper:
+                              description: Protocol Mapper to use
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                clients:
+                  description: A set of Keycloak Clients.
+                  items:
+                    properties:
+                      access:
+                        additionalProperties:
+                          type: boolean
+                        description: Access options.
+                        type: object
+                      adminUrl:
+                        description: Application Admin URL.
+                        type: string
+                      attributes:
+                        additionalProperties:
+                          type: string
+                        description: Client Attributes.
+                        type: object
+                      baseUrl:
+                        description: Application base URL.
+                        type: string
+                      bearerOnly:
+                        description: True if a client supports only Bearer Tokens.
+                        type: boolean
+                      clientAuthenticatorType:
+                        description: What Client authentication type to use.
+                        type: string
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      consentRequired:
+                        description: True if Consent Screen is required.
+                        type: boolean
+                      defaultClientScopes:
+                        description: A list of default client scopes. Default client
+                          scopes are always applied when issuing OpenID Connect tokens
+                          or SAML assertions for this client.
+                        items:
+                          type: string
+                        type: array
+                      defaultRoles:
+                        description: Default Client roles.
+                        items:
+                          type: string
+                        type: array
+                      description:
+                        description: Client description.
+                        type: string
+                      directAccessGrantsEnabled:
+                        description: True if Direct Grant is enabled.
+                        type: boolean
+                      enabled:
+                        description: Client enabled flag.
+                        type: boolean
+                      frontchannelLogout:
+                        description: True if this client supports Front Channel logout.
+                        type: boolean
+                      fullScopeAllowed:
+                        description: True if Full Scope is allowed.
+                        type: boolean
+                      id:
+                        description: Client ID. If not specified, automatically generated.
+                        type: string
+                      implicitFlowEnabled:
+                        description: True if Implicit flow is enabled.
+                        type: boolean
+                      name:
+                        description: Client name.
+                        type: string
+                      nodeReRegistrationTimeout:
+                        description: Node registration timeout.
+                        type: integer
+                      notBefore:
+                        description: Not Before setting.
+                        type: integer
+                      optionalClientScopes:
+                        description: A list of optional client scopes. Optional client
+                          scopes are applied when issuing tokens for this client,
+                          but only when they are requested by the scope parameter
+                          in the OpenID Connect authorization request.
+                        items:
+                          type: string
+                        type: array
+                      protocol:
+                        description: Protocol used for this Client.
+                        type: string
+                      protocolMappers:
+                        description: Protocol Mappers.
+                        items:
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config options.
+                              type: object
+                            consentRequired:
+                              description: True if Consent Screen is required.
+                              type: boolean
+                            consentText:
+                              description: Text to use for displaying Consent Screen.
+                              type: string
+                            id:
+                              description: Protocol Mapper ID.
+                              type: string
+                            name:
+                              description: Protocol Mapper Name.
+                              type: string
+                            protocol:
+                              description: Protocol to use.
+                              type: string
+                            protocolMapper:
+                              description: Protocol Mapper to use
+                              type: string
+                          type: object
+                        type: array
+                      publicClient:
+                        description: True if this is a public Client.
+                        type: boolean
+                      redirectUris:
+                        description: A list of valid Redirection URLs.
+                        items:
+                          type: string
+                        type: array
+                      rootUrl:
+                        description: Application root URL.
+                        type: string
+                      secret:
+                        description: Client Secret. The Operator will automatically
+                          create a Secret based on this value.
+                        type: string
+                      serviceAccountsEnabled:
+                        description: True if Service Accounts are enabled.
+                        type: boolean
+                      standardFlowEnabled:
+                        description: True if Standard flow is enabled.
+                        type: boolean
+                      surrogateAuthRequired:
+                        description: Surrogate Authentication Required option.
+                        type: boolean
+                      useTemplateConfig:
+                        description: True to use a Template Config.
+                        type: boolean
+                      useTemplateMappers:
+                        description: True to use Template Mappers.
+                        type: boolean
+                      useTemplateScope:
+                        description: True to use Template Scope.
+                        type: boolean
+                      webOrigins:
+                        description: A list of valid Web Origins.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - clientId
+                    type: object
+                  type: array
+                defaultLocale:
+                  description: Default Locale
+                  type: string
+                displayName:
+                  description: Realm display name.
+                  type: string
+                duplicateEmailsAllowed:
+                  description: Duplicate emails
+                  type: boolean
+                editUsernameAllowed:
+                  description: Edit username
+                  type: boolean
+                emailTheme:
+                  description: Email Theme
+                  type: string
+                enabled:
+                  description: Realm enabled flag.
+                  type: boolean
+                eventsEnabled:
+                  description: 'Enable events recording TODO: change to values and
+                    use kubebuilder default annotation once supported'
+                  type: boolean
+                eventsListeners:
+                  description: A set of Event Listeners.
+                  items:
+                    type: string
+                  type: array
+                failureFactor:
+                  description: Max Login Failures
+                  format: int32
+                  type: integer
+                id:
+                  type: string
+                identityProviders:
+                  description: A set of Identity Providers.
+                  items:
+                    properties:
+                      addReadTokenRoleOnCreate:
+                        description: Adds Read Token role when creating this Identity
+                          Provider.
+                        type: boolean
+                      alias:
+                        description: Identity Provider Alias.
+                        type: string
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: Identity Provider config.
+                        type: object
+                      displayName:
+                        description: Identity Provider Display Name.
+                        type: string
+                      enabled:
+                        description: Identity Provider enabled flag.
+                        type: boolean
+                      firstBrokerLoginFlowAlias:
+                        description: Identity Provider First Broker Login Flow Alias.
+                        type: string
+                      internalId:
+                        description: Identity Provider Internal ID.
+                        type: string
+                      linkOnly:
+                        description: Identity Provider Link Only setting.
+                        type: boolean
+                      postBrokerLoginFlowAlias:
+                        description: Identity Provider Post Broker Login Flow Alias.
+                        type: string
+                      providerId:
+                        description: Identity Provider ID.
+                        type: string
+                      storeToken:
+                        description: Identity Provider Store to Token.
+                        type: boolean
+                      trustEmail:
+                        description: Identity Provider Trust Email.
+                        type: boolean
+                    type: object
+                  type: array
+                internationalizationEnabled:
+                  description: Internationalization Enabled
+                  type: boolean
+                loginTheme:
+                  description: Login Theme
+                  type: string
+                loginWithEmailAllowed:
+                  description: Login with email
+                  type: boolean
+                maxDeltaTimeSeconds:
+                  description: Failure Reset Time
+                  format: int32
+                  type: integer
+                maxFailureWaitSeconds:
+                  description: Max Wait
+                  format: int32
+                  type: integer
+                minimumQuickLoginWaitSeconds:
+                  description: Minimum Quick Login Wait
+                  format: int32
+                  type: integer
+                permanentLockout:
+                  description: Permanent Lockout
+                  type: boolean
+                quickLoginCheckMilliSeconds:
+                  description: Quick Login Check Milli Seconds
+                  format: int64
+                  type: integer
+                realm:
+                  description: Realm name.
+                  type: string
+                registrationAllowed:
+                  description: User registration
+                  type: boolean
+                registrationEmailAsUsername:
+                  description: Email as username
+                  type: boolean
+                rememberMe:
+                  description: Remember me
+                  type: boolean
+                resetPasswordAllowed:
+                  description: Forgot password
+                  type: boolean
+                roles:
+                  description: Roles
+                  properties:
+                    client:
+                      additionalProperties:
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      description: Client Roles
+                      type: object
+                    realm:
+                      description: Realm Roles
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                        properties:
+                          attributes:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Role Attributes
+                            type: object
+                          clientRole:
+                            description: Client Role
+                            type: boolean
+                          composite:
+                            description: Composite
+                            type: boolean
+                          composites:
+                            description: Composites
+                            properties:
+                              client:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Map client => []role
+                                type: object
+                              realm:
+                                description: Realm roles
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          containerId:
+                            description: Container Id
+                            type: string
+                          description:
+                            description: Description
+                            type: string
+                          id:
+                            description: Id
+                            type: string
+                          name:
+                            description: Name
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                scopeMappings:
+                  description: Scope Mappings
+                  items:
+                    description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                    properties:
+                      client:
+                        description: Client
+                        type: string
+                      clientScope:
+                        description: Client Scope
+                        type: string
+                      roles:
+                        description: Roles
+                        items:
+                          type: string
+                        type: array
+                      self:
+                        description: Self
+                        type: string
+                    type: object
+                  type: array
+                smtpServer:
+                  additionalProperties:
+                    type: string
+                  description: Email
+                  type: object
+                sslRequired:
+                  description: Require SSL
+                  type: string
+                supportedLocales:
+                  description: Supported Locales
+                  items:
+                    type: string
+                  type: array
+                userFederationMappers:
+                  description: User federation mappers are extension points triggered
+                    by the user federation at various points.
+                  items:
+                    description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers
+                      https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: User federation mapper config.
+                        type: object
+                      federationMapperType:
+                        type: string
+                      federationProviderDisplayName:
+                        description: The displayName for the user federation provider
+                          this mapper applies to.
+                        type: string
+                      id:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  type: array
+                userFederationProviders:
+                  description: Point keycloak to an external user provider to validate
+                    credentials or pull in identity information.
+                  items:
+                    description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: User federation provider config.
+                        type: object
+                      displayName:
+                        description: The display name of this provider instance.
+                        type: string
+                      fullSyncPeriod:
+                        format: int32
+                        type: integer
+                      id:
+                        description: The ID of this provider
+                        type: string
+                      priority:
+                        description: The priority of this provider when looking up
+                          users or adding a user.
+                        format: int32
+                        type: integer
+                      providerName:
+                        description: The name of the user provider, such as "ldap",
+                          "kerberos" or a custom SPI.
+                        type: string
+                    type: object
+                  type: array
+                users:
+                  description: A set of Keycloak Users.
+                  items:
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: A set of Attributes.
+                        type: object
+                      clientRoles:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: A set of Client Roles.
+                        type: object
+                      credentials:
+                        description: A set of Credentials.
+                        items:
+                          properties:
+                            temporary:
+                              description: True if this credential object is temporary.
+                              type: boolean
+                            type:
+                              description: Credential Type.
+                              type: string
+                            value:
+                              description: Credential Value.
+                              type: string
+                          type: object
+                        type: array
+                      email:
+                        description: Email.
+                        type: string
+                      emailVerified:
+                        description: True if email has already been verified.
+                        type: boolean
+                      enabled:
+                        description: User enabled flag.
+                        type: boolean
+                      federatedIdentities:
+                        description: A set of Federated Identities.
+                        items:
+                          properties:
+                            identityProvider:
+                              description: Federated Identity Provider.
+                              type: string
+                            userId:
+                              description: Federated Identity User ID.
+                              type: string
+                            userName:
+                              description: Federated Identity User Name.
+                              type: string
+                          type: object
+                        type: array
+                      firstName:
+                        description: First Name.
+                        type: string
+                      groups:
+                        description: A set of Groups.
+                        items:
+                          type: string
+                        type: array
+                      id:
+                        description: User ID.
+                        type: string
+                      lastName:
+                        description: Last Name.
+                        type: string
+                      realmRoles:
+                        description: A set of Realm Roles.
+                        items:
+                          type: string
+                        type: array
+                      requiredActions:
+                        description: A set of Required Actions.
+                        items:
+                          type: string
+                        type: array
+                      username:
+                        description: User Name.
+                        type: string
+                    type: object
+                  type: array
+                verifyEmail:
+                  description: Verify email
+                  type: boolean
+                waitIncrementSeconds:
+                  description: Wait Increment
+                  format: int32
+                  type: integer
+              required:
+              - realm
+              type: object
+            realmOverrides:
+              description: A list of overrides to the default Realm behavior.
+              items:
+                properties:
+                  forFlow:
+                    description: Flow to be overridden.
+                    type: string
+                  identityProvider:
+                    description: Identity Provider to be overridden.
+                    type: string
+                required:
+                - identityProvider
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            unmanaged:
+              description: When set to true, this KeycloakRealm will be marked as
+                unmanaged and not be managed by this operator. It can then be used
+                for targeting purposes.
+              type: boolean
+          required:
+          - realm
+          type: object
+        status:
+          description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+          properties:
+            loginURL:
+              description: TODO
+              type: string
+            message:
+              description: Human-readable message indicating details about current
+                operator phase or error.
+              type: string
+            phase:
+              description: Current phase of the operator.
+              type: string
+            ready:
+              description: True if all resources are in a ready state and all work
+                is done.
+              type: boolean
+            secondaryResources:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              description: 'A map of all the secondary resources types and names created
+                for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                ]'
+              type: object
+          required:
+          - loginURL
+          - message
+          - phase
+          - ready
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/keycloak-operator/crds/keycloak.org_keycloaks_crd.yaml
+++ b/charts/keycloak-operator/crds/keycloak.org_keycloaks_crd.yaml
@@ -1,0 +1,1074 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Keycloak is the Schema for the keycloaks API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeycloakSpec defines the desired state of Keycloak.
+          properties:
+            extensions:
+              description: A list of extensions, where each one is a URL to a JAR
+                files that will be deployed in Keycloak.
+              items:
+                type: string
+              type: array
+              x-kubernetes-list-type: set
+            external:
+              description: Contains configuration for external Keycloak instances.
+                Unmanaged needs to be set to true to use this.
+              properties:
+                adminPassword:
+                  description: The admin password to use for keycloak. Needs to be
+                    set if external is true.
+                  type: string
+                adminUsername:
+                  description: The admin username to use for keycloak. Needs to be
+                    set if external is true.
+                  type: string
+                enabled:
+                  description: If set to true, this Keycloak will be treated as an
+                    external instance. The unmanaged field also needs to be set to
+                    true if this field is true.
+                  type: boolean
+                url:
+                  description: The URL to use for the keycloak admin API. Needs to
+                    be set if external is true.
+                  type: string
+              type: object
+            externalAccess:
+              description: Controls external Ingress/Route settings.
+              properties:
+                enabled:
+                  description: If set to true, the Operator will create an Ingress
+                    or a Route pointing to Keycloak.
+                  type: boolean
+                host:
+                  description: If set, the Operator will use value of host for Ingress/Route
+                    host instead of default value keycloak.local for ingress and automatically
+                    chosen name for Route
+                  type: string
+                tlsTermination:
+                  description: TLS Termination type for the external access. Setting
+                    this field to "reencrypt" will terminate TLS on the Ingress/Route
+                    level. Setting this field to "passthrough" will send encrypted
+                    traffic to the Pod. If unspecified, defaults to "reencrypt". Note,
+                    that this setting has no effect on Ingress as Ingress TLS settings
+                    are not reconciled by this operator. In other words, Ingress TLS
+                    configuration is the same in both cases and it is up to the user
+                    to configure TLS section of the Ingress.
+                  type: string
+              type: object
+            externalDatabase:
+              description: "Controls external database settings. Using an external
+                database requires providing a secret containing credentials as well
+                as connection details. Here's an example of such secret: \n     apiVersion:
+                v1     kind: Secret     metadata:         name: keycloak-db-secret
+                \        namespace: keycloak     stringData:         POSTGRES_DATABASE:
+                <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database
+                IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External
+                Database Port>         # Strongly recommended to use <'Keycloak CR
+                Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD:
+                <Database Password>         # Required for AWS Backup functionality
+                \        POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database
+                Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and
+                POSTGRES_EXTERNAL_PORT are specifically required for creating connection
+                to the external database. The secret name is created using the following
+                convention:       <Custom Resource Name>-db-secret \n For more information,
+                please refer to the Operator documentation."
+              properties:
+                enabled:
+                  description: If set to true, the Operator will use an external database.
+                    pointing to Keycloak.
+                  type: boolean
+              type: object
+            instances:
+              description: Number of Keycloak instances in HA mode. Default is 1.
+              type: integer
+            keycloakDeploymentSpec:
+              description: Resources (Requests and Limits) for KeycloakDeployment.
+              properties:
+                experimental:
+                  description: 'Experimental section NOTE: This section might change
+                    or get removed without any notice. It may also cause the deployment
+                    to behave in an unpredictable fashion. Please use with care.'
+                  properties:
+                    affinity:
+                      description: Affinity settings
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    args:
+                      description: Arguments to the entrypoint. Translates into Container
+                        CMD.
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: Container command. Translates into Container ENTRYPOINT.
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP, status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    volumes:
+                      description: Additional volume mounts
+                      properties:
+                        defaultMode:
+                          description: Permissions mode.
+                          format: int32
+                          type: integer
+                        items:
+                          items:
+                            properties:
+                              configMap:
+                                description: ConfigMap mount
+                                properties:
+                                  items:
+                                    description: ConfigMap mount details
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  mountPath:
+                                    description: An absolute path where to mount it
+                                    type: string
+                                  name:
+                                    description: ConfigMap name
+                                    type: string
+                                required:
+                                - mountPath
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                resources:
+                  description: Resources (Requests and Limits) for the Pods.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+              type: object
+            migration:
+              description: Specify Migration configuration
+              properties:
+                backups:
+                  description: Set it to config backup policy for migration
+                  properties:
+                    enabled:
+                      description: If set to true, the operator will do database backup
+                        before doing migration
+                      type: boolean
+                  type: object
+                strategy:
+                  description: Specify migration strategy
+                  type: string
+              type: object
+            multiAvailablityZones:
+              description: Specify PodAntiAffinity settings for Keycloak deployment
+                in Multi AZ
+              properties:
+                enabled:
+                  description: If set to true, the operator will create a podAntiAffinity
+                    settings for the Keycloak deployment.
+                  type: boolean
+              type: object
+            podDisruptionBudget:
+              description: Specify PodDisruptionBudget configuration.
+              properties:
+                enabled:
+                  description: If set to true, the operator will create a PodDistruptionBudget
+                    for the Keycloak deployment and set its `maxUnavailable` value
+                    to 1.
+                  type: boolean
+              type: object
+            postgresDeploymentSpec:
+              description: Resources (Requests and Limits) for PostgresDeployment.
+              properties:
+                resources:
+                  description: Resources (Requests and Limits) for the Pods.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+              type: object
+            profile:
+              description: Profile used for controlling Operator behavior. Default
+                is empty.
+              type: string
+            storageClassName:
+              description: Name of the StorageClass for Postgresql Persistent Volume
+                Claim
+              type: string
+            unmanaged:
+              description: When set to true, this Keycloak will be marked as unmanaged
+                and will not be managed by this operator. It can then be used for
+                targeting purposes.
+              type: boolean
+          type: object
+        status:
+          description: KeycloakStatus defines the observed state of Keycloak.
+          properties:
+            credentialSecret:
+              description: The secret where the admin credentials are to be found.
+              type: string
+            internalURL:
+              description: Service IP and Port for in-cluster access to the keycloak
+                instance.
+              type: string
+            message:
+              description: Human-readable message indicating details about current
+                operator phase or error.
+              type: string
+            phase:
+              description: Current phase of the operator.
+              type: string
+            ready:
+              description: True if all resources are in a ready state and all work
+                is done.
+              type: boolean
+            secondaryResources:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              description: 'A map of all the secondary resources types and names created
+                for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                ].'
+              type: object
+            version:
+              description: Version of Keycloak or RHSSO running on the cluster.
+              type: string
+          required:
+          - credentialSecret
+          - internalURL
+          - message
+          - phase
+          - ready
+          - version
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/keycloak-operator/crds/keycloak.org_keycloakusers_crd.yaml
+++ b/charts/keycloak-operator/crds/keycloak.org_keycloakusers_crd.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KeycloakUser is the Schema for the keycloakusers API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeycloakUserSpec defines the desired state of KeycloakUser.
+          properties:
+            realmSelector:
+              description: Selector for looking up KeycloakRealm Custom Resources.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            user:
+              description: Keycloak User REST object.
+              properties:
+                attributes:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: A set of Attributes.
+                  type: object
+                clientRoles:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: A set of Client Roles.
+                  type: object
+                credentials:
+                  description: A set of Credentials.
+                  items:
+                    properties:
+                      temporary:
+                        description: True if this credential object is temporary.
+                        type: boolean
+                      type:
+                        description: Credential Type.
+                        type: string
+                      value:
+                        description: Credential Value.
+                        type: string
+                    type: object
+                  type: array
+                email:
+                  description: Email.
+                  type: string
+                emailVerified:
+                  description: True if email has already been verified.
+                  type: boolean
+                enabled:
+                  description: User enabled flag.
+                  type: boolean
+                federatedIdentities:
+                  description: A set of Federated Identities.
+                  items:
+                    properties:
+                      identityProvider:
+                        description: Federated Identity Provider.
+                        type: string
+                      userId:
+                        description: Federated Identity User ID.
+                        type: string
+                      userName:
+                        description: Federated Identity User Name.
+                        type: string
+                    type: object
+                  type: array
+                firstName:
+                  description: First Name.
+                  type: string
+                groups:
+                  description: A set of Groups.
+                  items:
+                    type: string
+                  type: array
+                id:
+                  description: User ID.
+                  type: string
+                lastName:
+                  description: Last Name.
+                  type: string
+                realmRoles:
+                  description: A set of Realm Roles.
+                  items:
+                    type: string
+                  type: array
+                requiredActions:
+                  description: A set of Required Actions.
+                  items:
+                    type: string
+                  type: array
+                username:
+                  description: User Name.
+                  type: string
+              type: object
+          required:
+          - user
+          type: object
+        status:
+          description: KeycloakUserStatus defines the observed state of KeycloakUser.
+          properties:
+            message:
+              description: Human-readable message indicating details about current
+                operator phase or error.
+              type: string
+            phase:
+              description: Current phase of the operator.
+              type: string
+          required:
+          - message
+          - phase
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/keycloak-operator/templates/_helpers.tpl
+++ b/charts/keycloak-operator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/keycloak-operator/templates/cluster_role.yaml
+++ b/charts/keycloak-operator/templates/cluster_role.yaml
@@ -1,0 +1,130 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keycloak-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - list
+      - get
+      - create
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - keycloak-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - keycloak.org
+    resources:
+      - keycloaks
+      - keycloaks/status
+      - keycloaks/finalizers
+      - keycloakrealms
+      - keycloakrealms/status
+      - keycloakrealms/finalizers
+      - keycloakclients
+      - keycloakclients/status
+      - keycloakclients/finalizers
+      - keycloakbackups
+      - keycloakbackups/status
+      - keycloakbackups/finalizers
+      - keycloakusers
+      - keycloakusers/status
+      - keycloakusers/finalizers
+    verbs:
+      - get
+      - list
+      - update
+      - watch

--- a/charts/keycloak-operator/templates/cluster_role_binding.yaml
+++ b/charts/keycloak-operator/templates/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keycloak-operator
+roleRef:
+  name: keycloak-operator
+  kind: ClusterRole
+  apiGroup: ""
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-operator
+    namespace: {{ .Release.Namespace }}

--- a/charts/keycloak-operator/templates/operator.yaml
+++ b/charts/keycloak-operator/templates/operator.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-operator
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: keycloak-operator
+  template:
+    metadata:
+      labels:
+        name: keycloak-operator
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}  
+    spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      serviceAccountName: keycloak-operator
+      securityContext:
+        runAsUser: 100 # because 100 is consul-template user id and is allowed to restart the container.
+      imagePullSecrets:
+      - name: {{.Values.image.registry }}
+      containers:
+        - name: keycloak-operator
+          image: "{{.Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+          - keycloak-operator
+          {{- if .Values.debug }}
+          args:
+          - --zap-devel
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: K8S_CLUSTER_IDENTIFIER
+              value: {{ .Values.clusterIdentifier | quote }}
+            - name: WATCH_NAMESPACE
+              value: {{ .Values.watchNamespace }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "keycloak-operator"

--- a/charts/keycloak-operator/templates/service_account.yaml
+++ b/charts/keycloak-operator/templates/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-operator

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -1,0 +1,38 @@
+# Default values for keycloak-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  registry: reg.vibrenthealth.com
+  repository: vibrent-ops/keycloak-operator
+  tag: test
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+clusterIdentifier: "random-cluster-id"
+
+debug: true
+watchNamespace: ""
+
+podAnnotations: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
@@ -88,11 +88,11 @@ func (i *KeycloakRealmReconciler) getDesiredRealmState(state *common.RealmState,
 			Ref: cr,
 			Msg: fmt.Sprintf("create realm %v/%v", cr.Namespace, cr.Spec.Realm.Realm),
 		}
-	} else {
-		return &common.UpdateRealmAction{
-			Ref: cr,
-			Msg: fmt.Sprintf("update realm %v/%v", cr.Namespace, cr.Spec.Realm.Realm),
-		}
+	}
+
+	return &common.UpdateRealmAction{
+		Ref: cr,
+		Msg: fmt.Sprintf("update realm %v/%v", cr.Namespace, cr.Spec.Realm.Realm),
 	}
 }
 


### PR DESCRIPTION
Added initial Helm Chart with Watch_Namespace configured. 

When the WATCH_NAMESPACE is set to an empty string, the operator should monitor for changes across all namespaces in the cluster.

When WATCH_NAMESPACE is a comma delimited list, then changes should be monitored for in the provided namespaces

JIRA ID: AC-94086
