### PR TITLE
Add helmChart label to operator deployment so pods roll when new version deployed.

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Keycloak Operator
 name: keycloak-operator
-version: 1.5.0
+version: 1.5.1

--- a/charts/keycloak-operator/templates/operator.yaml
+++ b/charts/keycloak-operator/templates/operator.yaml
@@ -10,6 +10,7 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
         name: keycloak-operator
       {{- if .Values.podAnnotations }}
       annotations:


### PR DESCRIPTION
AC-0000

This change will reduce deployment complexity by causing pods to be rolled whenever a new chart version is deployed.