### PR TITLE
fix(workers): AC-122514 Increase client controller concurrency to 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Vibrent forked the Keycloak Operator to make the following custom changes:
 * Support for the Browser Security Headers Configuration in KeycloakRealm CRD: [AC-120343](https://vibrenthealth.atlassian.net/browse/AC-120343)
 * Support for authentication flow bindings in the KeycloakRealm CRD
 * Support for managing realm's required actions from the KeycloakRealm CRD: [AC-120810](https://vibrenthealth.atlassian.net/browse/AC-120810) and [AC-120811](https://vibrenthealth.atlassian.net/browse/AC-120811)
+* Increase reconcile concurrency for client controller to 5: [AC-122514](https://vibrenthealth.atlassian.net/browse/AC-122514)
 
 ### Updating Custom Resource Definitions (CRD)
 Currently the CRDs in the Helm Chart are exact copies of the CRDs found in the /deploy/crds directory. Therefore, when updating a CRD you must replace the appropriate CRD found in /charts/keycloak-operator/crds with the updated CRD to ensure the Helm Chart contains the most current updates when deployed.

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Keycloak Operator
 name: keycloak-operator
-version: 1.6.5
+version: 1.6.6

--- a/pkg/controller/keycloakclient/keycloakclient_controller.go
+++ b/pkg/controller/keycloakclient/keycloakclient_controller.go
@@ -52,7 +52,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 5})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
AC-122514

Allowing 5 workers to reconcile concurrently rather than the default (1) allows 20 clients in my local environment to be reconciled within 20 seconds (108 seconds with 1 thread).