### PR TITLE
fix(realm): Fix issue preventing KeycloakRealm clean up if target Keycloak was cleaned up first.

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Keycloak Operator
 name: keycloak-operator
-version: 1.7.3
+version: 1.7.4

--- a/pkg/controller/keycloakrealm/keycloakrealm_controller.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_controller.go
@@ -161,7 +161,7 @@ func (r *ReconcileKeycloakRealm) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{
 			RequeueAfter: RequeueDelayError,
 			Requeue:      true,
-		}, nil
+		}, r.manageSuccess(instance, realmLogger, instance.DeletionTimestamp != nil)
 	}
 
 	// The realm may be applicable to multiple keycloak instances,

--- a/test/e2e/keycloak_main_test.go
+++ b/test/e2e/keycloak_main_test.go
@@ -41,6 +41,7 @@ func TestKeycloakCRDS(t *testing.T) {
 	})
 	t.Run("KeycloakRealmsCRDTest", func(t *testing.T) {
 		runTestsFromCRDInterface(t, NewKeycloakRealmsCRDTestStruct())
+		runTestsFromCRDInterface(t, NewKeycloakRealmsDeletionTestStruct())
 	})
 	t.Run("KeycloakUsersCRDTest", func(t *testing.T) {
 		runTestsFromCRDInterface(t, NewKeycloakUserCRDTestStruct())

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -128,6 +128,25 @@ func WaitForKeycloakToBeReady(t *testing.T, framework *framework.Framework, name
 	})
 }
 
+func WaitForKeycloakToBeDeleted(t *testing.T, framework *framework.Framework, namespace string, name string) error {
+	keycloakCR := &keycloakv1alpha1.Keycloak{}
+
+	return WaitForCondition(t, framework.KubeClient, func(t *testing.T, c kubernetes.Interface) error {
+		err := GetNamespacedObject(framework, namespace, name, keycloakCR)
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				return nil // deleted
+			}
+			return err
+		}
+		keycloakCRParsed, err := json.Marshal(keycloakCR)
+		if err != nil {
+			return err
+		}
+		return errors.Errorf("keycloak is not deleted \nCurrent CR value : %s", string(keycloakCRParsed))
+	})
+}
+
 func WaitForRealmToBeReady(t *testing.T, framework *framework.Framework, namespace string) error {
 	keycloakRealmCR := &keycloakv1alpha1.KeycloakRealm{}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix was verified by the new integration test, which fails when executed without this change, then passes when the controller change is introduced.

## JIRA reference
<!--- If it fixes an open issue, please link to the issue here. use syntax <PROJECT>-####-->
AC-127203

## Checklist:
- [x] Run `make code/lint` and apply changes.
- [x] Run `make code/gen` and apply changes as separate commit.
- [x] Git and Jenkins pipelines all pass
- [x] Set new chart version
- [ ] Updates to README.md (update change-log at minimum)

<!-- (Add this section if applicable)
## Additional Notes 
-->
