### PR TITLE
feat(deps): AC-153404 Update based image used by Dockerfile to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # See README.md for how we alter the image repository based for Github actions and internal Jenkins pipeline
 ARG FIRST_FROM_IMAGE=artifacts.ssk8s.vibrenthealth.com/dockerhub/openshift/origin-release:golang-1.13
-ARG SECOND_FROM_IMAGE=artifacts.ssk8s.vibrenthealth.com/dockerhub/coolbeevip/ubi8-ubi-minimal:latest
+ARG SECOND_FROM_IMAGE=artifacts.ssk8s.vibrenthealth.com/dockerhub/redhat/ubi8-minimal:latest
 FROM ${FIRST_FROM_IMAGE} AS build-env
 
 COPY . /src/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def branch = env.BRANCH_NAME.replace(/\//, '-')
 Boolean publishOperator = false
 
 podTemplate(
-        cloud: 'default',
+        cloud: 'bldk8s',
         name: label,
         label: label,
         containers: kubeUtils.getCiContainers(containerList: ["kubectl", "docker", "helm", "python"]),

--- a/README.md
+++ b/README.md
@@ -46,14 +46,17 @@ When starting a new production chance, increment the first or middle numeral (`X
 * New logic for updating "realm roles" in the KeycloakRealm reconcile logic.
 * New logic for updating custom Authentication Flows used for participant login, registration, and password reset (Not all types of update are supported).
 
-#### 1.8.X
+#### 1.8.0
 * New logic for updating "realm clientScopes" and "realm requiredActions" in the KeycloakRealm reconcile logic.
 
-#### 1.9.X
+#### 1.9.0
 * Remove support for a managed Keycloak PodDisruptionBudget: [AC-144568](https://vibrenthealth.atlassian.net/browse/AC-144568)
 
-#### 1.10.X
+#### 1.10.0
 * Migrate docker repository and KC's dependency to the new Harbor instance.https://vibrenthealth.atlassian.net/browse/AC-150267
+
+#### 1.10.1
+* Update coordinates of Dockerfile base image to official RedHat (through Vibrent proxy)
 
 ### Updating Custom Resource Definitions (CRD)
 Currently, the CRDs in the Helm Chart are exact copies of the CRDs found in the /deploy/crds directory. Therefore, when updating a CRD you must replace the appropriate CRD found in /charts/keycloak-operator/crds with the updated CRD to ensure the Helm Chart contains the most current updates when deployed.

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Keycloak Operator
 name: keycloak-operator
-version: 1.10.0
+version: 1.10.1


### PR DESCRIPTION
## Description
The primary source image for our Dockerfile was a 3rd party mirror no longer maintained. This change updates to the officially hosted redhat image (through our harbor proxy).

NOTE: Changes to `Jenkinsfile` and `ci.yaml` are not directly related, but required for the CI pipeline to pass.

## JIRA reference
AC-153404

## Checklist:
- [x] Run `make code/lint` and apply changes.
- [x] Run `make code/gen` and apply changes as separate commit.
- [ ] Git and Jenkines pipelines all pass
- [x] Set new chart version
- [x] Updates to README.md (update change-log at minimum)

